### PR TITLE
Enable putting different certificates for Raft peers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -226,7 +226,7 @@ vault_raft_cluster_members: |
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
       "tls_ca_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
       "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
-      "tls_key_file": "{{ vault_tls_certs_path }}/CA.key"
+      "tls_key_file": "{{ vault_tls_certs_path }}/CA.crt"
     }{% if not loop.last %},{% endif %}
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -224,7 +224,10 @@ vault_raft_cluster_members: |
       "peer": "{{ server }}",
       "api_addr": "{{ hostvars[server]['vault_api_addr'] |
       default(vault_protocol + '://' +
-      hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+      hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
+      "tls_ca_file": vault_tls_certs_path + item + '.int.jusmundi.com.pem',
+      "tls_cert_file": vault_tls_certs_path + item + '.int.jusmundi.com.pem',
+      "tls_key_file": vault_tls_certs_path + item + '.int.jusmundi.com.key'
     },
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -226,7 +226,7 @@ vault_raft_cluster_members: |
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
       "tls_ca_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
       "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
-      "tls_key_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.key"
+      "tls_key_file": "{{ vault_tls_certs_path }}/CA.key"
     }{% if not loop.last %},{% endif %}
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -222,13 +222,12 @@ vault_raft_cluster_members: |
   {% for server in groups[vault_raft_group_name] %}
     {
       "peer": "{{ server }}",
-      "api_addr": "{{ hostvars[server]['vault_api_addr'] |
-      default(vault_protocol + '://' +
+      "api_addr": "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' +
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
-      "tls_ca_file": {{ vault_tls_certs_path }} + {{ server }} + '.int.jusmundi.com.pem',
-      "tls_cert_file": {{ vault_tls_certs_path }} + {{ server }} + '.int.jusmundi.com.pem',
-      "tls_key_file": {{ vault_tls_certs_path }} + {{ server }} + '.int.jusmundi.com.key'
-    },
+      "tls_ca_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
+      "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
+      "tls_key_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.key"
+    }{% if not loop.last %},{% endif %}
   {% endfor %}
   ]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -225,9 +225,9 @@ vault_raft_cluster_members: |
       "api_addr": "{{ hostvars[server]['vault_api_addr'] |
       default(vault_protocol + '://' +
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
-      "tls_ca_file": vault_tls_certs_path + item + '.int.jusmundi.com.pem',
-      "tls_cert_file": vault_tls_certs_path + item + '.int.jusmundi.com.pem',
-      "tls_key_file": vault_tls_certs_path + item + '.int.jusmundi.com.key'
+      "tls_ca_file": vault_tls_certs_path + server + '.int.jusmundi.com.pem',
+      "tls_cert_file": vault_tls_certs_path + server + '.int.jusmundi.com.pem',
+      "tls_key_file": vault_tls_certs_path + server + '.int.jusmundi.com.key'
     },
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -227,7 +227,7 @@ vault_raft_cluster_members: |
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
       "tls_key_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_altname_suffix }}.key",
       "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_altname_suffix }}.crt",
-      "tls_ca_file": "{{ vault_tls_certs_path }}/cacert.pem"
+      "tls_ca_file": "{{ vault_tls_certs_path }}/{{ vault_tls_client_ca_file }}"
     }{% if not loop.last %},{% endif %}
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,6 +217,7 @@ vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_f
 # raft storage settings
 vault_backend: raft
 vault_raft_group_name: "vault_raft_servers"
+vault_raft_altname_suffix: example.com
 vault_raft_cluster_members: |
   [
   {% for server in groups[vault_raft_group_name] %}
@@ -224,9 +225,9 @@ vault_raft_cluster_members: |
       "peer": "{{ server }}",
       "api_addr": "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' +
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
-      "tls_ca_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
-      "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.int.jusmundi.com.pem",
-      "tls_key_file": "{{ vault_tls_certs_path }}/CA.crt"
+      "tls_key_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_raft_altname_suffix }}.key",
+      "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_raft_altname_suffix }}.crt",
+      "tls_ca_file": "{{ vault_tls_certs_path }}/cacert.pem"
     }{% if not loop.last %},{% endif %}
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -225,9 +225,9 @@ vault_raft_cluster_members: |
       "api_addr": "{{ hostvars[server]['vault_api_addr'] |
       default(vault_protocol + '://' +
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
-      "tls_ca_file": vault_tls_certs_path + server + '.int.jusmundi.com.pem',
-      "tls_cert_file": vault_tls_certs_path + server + '.int.jusmundi.com.pem',
-      "tls_key_file": vault_tls_certs_path + server + '.int.jusmundi.com.key'
+      "tls_ca_file": {{ vault_tls_certs_path }} + {{ server }} + '.int.jusmundi.com.pem',
+      "tls_cert_file": {{ vault_tls_certs_path }} + {{ server }} + '.int.jusmundi.com.pem',
+      "tls_key_file": {{ vault_tls_certs_path }} + {{ server }} + '.int.jusmundi.com.key'
     },
   {% endfor %}
   ]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,7 +217,7 @@ vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_f
 # raft storage settings
 vault_backend: raft
 vault_raft_group_name: "vault_raft_servers"
-vault_raft_altname_suffix: example.com
+vault_altname_suffix: example.com
 vault_raft_cluster_members: |
   [
   {% for server in groups[vault_raft_group_name] %}
@@ -225,8 +225,8 @@ vault_raft_cluster_members: |
       "peer": "{{ server }}",
       "api_addr": "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' +
       hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}",
-      "tls_key_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_raft_altname_suffix }}.key",
-      "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_raft_altname_suffix }}.crt",
+      "tls_key_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_altname_suffix }}.key",
+      "tls_cert_file": "{{ vault_tls_certs_path }}/{{ server }}.{{ vault_altname_suffix }}.crt",
       "tls_ca_file": "{{ vault_tls_certs_path }}/cacert.pem"
     }{% if not loop.last %},{% endif %}
   {% endfor %}

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -35,10 +35,9 @@ storage "raft" {
     {% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
     {% endif %}
-    leader_ca_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
-    leader_client_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
-    leader_client_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
-  }
+    leader_ca_cert_file = "{{ raft_peer.tls_ca_file if raft_peer.tls_ca_file else (vault_backend_tls_certs_path ~ '/' ~ vault_backend_tls_ca_file) }}"
+    leader_client_cert_file = "{{ raft_peer.tls_cert_file if raft_peer.tls_cert_file else (vault_backend_tls_certs_path ~ '/' ~ vault_backend_tls_cert_file) }}"
+    leader_client_key_file = "{{ raft_peer.tls_key_file if raft_peer.tls_key_file else (vault_backend_tls_private_path ~ '/' ~ vault_backend_tls_key_file) }}"  }
     {% else %}
   retry_join {
     leader_api_addr =  "{{ raft_peer.api_addr }}"


### PR DESCRIPTION
This is needed to be able to provide multiple certificates and keys for Raft peers all while ensuring that they are using a common CA certificate.